### PR TITLE
Phpunit update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "psr-4": { "MathPHP\\": "src/" }
   },
   "require-dev": {
-      "phpunit/phpunit": "7.*",
+      "phpunit/phpunit": ">=6.0",
       "php-coveralls/php-coveralls": "^2.0",
       "squizlabs/php_codesniffer": "3.*",
       "phpstan/phpstan": "*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "psr-4": { "MathPHP\\": "src/" }
   },
   "require-dev": {
-      "phpunit/phpunit": "6.*",
+      "phpunit/phpunit": "7.*",
       "php-coveralls/php-coveralls": "^2.0",
       "squizlabs/php_codesniffer": "3.*",
       "phpstan/phpstan": "*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "psr-4": { "MathPHP\\": "src/" }
   },
   "require-dev": {
-      "phpunit/phpunit": "6.*-7.*",
+      "phpunit/phpunit": ">=6.0 <8.0",
       "php-coveralls/php-coveralls": "^2.0",
       "squizlabs/php_codesniffer": "3.*",
       "phpstan/phpstan": "*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "psr-4": { "MathPHP\\": "src/" }
   },
   "require-dev": {
-      "phpunit/phpunit": ">=6.0",
+      "phpunit/phpunit": "6.*-7.*",
       "php-coveralls/php-coveralls": "^2.0",
       "squizlabs/php_codesniffer": "3.*",
       "phpstan/phpstan": "*",


### PR DESCRIPTION
Phpunit 6 support ended this month...PHP 7.0 support ended 2 months ago. PHPUnit 8 would allow for testing against PHP7.4, but one of our test cases errors against PHPUnit 8...might be worth looking into.